### PR TITLE
break out of foreach loop once name is found

### DIFF
--- a/src/MB_API.php
+++ b/src/MB_API.php
@@ -85,6 +85,8 @@ class MB_API {
 		foreach($this->apiMethods as $apiServiceName=>$apiMethods) {
 			if(in_array($name, $apiMethods)) {
 				$soapService = $apiServiceName;
+				//once name is found in apiMethods exit foreach loop.
+				break;
 			}
 		}
 		if(!empty($soapService)) {


### PR DESCRIPTION
This is a tiny addition but was going through the service and saw that we could do this to avoid looping unnecessarily.