### PR TITLE
prevent error when API does not return Results

### DIFF
--- a/src/MB_API.php
+++ b/src/MB_API.php
@@ -184,7 +184,7 @@ class MB_API {
 			return $res[0];
 		} else {
 			$arr = $this->replace_empty_arrays_with_nulls(json_decode(json_encode($res[0]),1));
-			if(is_array($arr['FunctionDataXmlResult']['Results']['Row'])) { 
+			if(isset($arr['FunctionDataXmlResult']['Results']['Row']) && is_array($arr['FunctionDataXmlResult']['Results']['Row'])) { 
 				$arr['FunctionDataXmlResult']['Results']['Row'] = $this->makeNumericArray($arr['FunctionDataXmlResult']['Results']['Row']);
 			}
 			return $arr;


### PR DESCRIPTION
This is a bug when there is an internal exception thrown from the API. The response does not contain an index called 'Results'. With this change the api response still gets returned with the API error code instead of throwing an error itself.

Let me know if you need further clarification.